### PR TITLE
actions runners: token + jobs via REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ fj-ex actions logs job --repo owner/name --latest --job-index 0
 # Cancel / rerun (preview first with --dry-run)
 fj-ex actions cancel --repo owner/name --run-index 50 --dry-run
 fj-ex actions rerun  --repo owner/name --latest --failed-only
+
+# Runner registration token + queued jobs (requires `fj auth login`)
+fj-ex actions runners token --repo owner/name
+fj-ex actions runners jobs  --repo owner/name --waiting
 ```
 
 > `--host` can be omitted — `fj-ex` infers it from the current repo's git remotes, or falls back to `$FJ_FALLBACK_HOST`.
@@ -46,6 +50,7 @@ fj-ex actions rerun  --repo owner/name --latest --failed-only
 | `actions cancel` | Cancel a running workflow |
 | `actions rerun` | Rerun a workflow (optionally `--failed-only`) |
 | `actions trigger` | Dispatch a `workflow_dispatch` event |
+| `actions runners` | Runner tokens + queued jobs (REST API; uses `fj` token store) |
 | `smoke-test` | Non-destructive end-to-end validation |
 
 Full command reference with all flags: [docs/commands.md](docs/commands.md)
@@ -61,6 +66,13 @@ Credentials and cookies are stored in plaintext at:
 ```text
 %APPDATA%\Cyborus\forgejo-cli\data\ui-creds.json   # Windows
 ~/.local/share/Cyborus/forgejo-cli/data/ui-creds.json  # Linux
+```
+
+`fj-ex actions runners` uses the API token stored by the official `fj` CLI at:
+
+```text
+%APPDATA%\Cyborus\forgejo-cli\data\keys.json   # Windows
+~/.local/share/Cyborus/forgejo-cli/data/keys.json  # Linux
 ```
 
 This is required for automatic re-login. Downloaded logs and artifacts may contain secrets — handle accordingly.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -103,6 +103,53 @@ fj-ex actions trigger --repo owner/name --workflow ci.yml --ref main
 
 ---
 
+## actions runners
+
+These commands use the Forgejo REST API and require being authenticated via the official `fj` CLI
+(API token stored by `fj`).
+
+Runner registration tokens:
+
+```sh
+# Repo scope (default if --repo is set / inferred)
+fj-ex actions runners token --repo owner/name
+
+# Global scope (admin endpoints)
+fj-ex actions runners token --scope global
+
+# Org scope
+fj-ex actions runners token --scope org --org my-org
+
+# User scope
+fj-ex actions runners token --scope user
+```
+
+Runner jobs:
+
+```sh
+# Show waiting jobs for the repo
+fj-ex actions runners jobs --repo owner/name --waiting
+
+# Filter by runner labels (repeatable; sent as labels=a,b)
+fj-ex actions runners jobs --scope global --label self-hosted --label linux
+```
+
+If you get a "No Forgejo API token found" error, authenticate via `fj`:
+
+```sh
+fj --host forge.example.com auth login
+fj --host forge.example.com auth add-key <USER>
+```
+
+Token store location (read by `fj-ex`):
+
+```text
+%APPDATA%/Cyborus/forgejo-cli/data/keys.json   # Windows
+~/.local/share/Cyborus/forgejo-cli/data/keys.json  # Linux
+```
+
+---
+
 ## actions workflows
 
 ```sh

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -971,6 +971,56 @@ fn fj_missing_api_token_error(base_url: &str) -> eyre::Report {
     )
 }
 
+fn resolve_runner_endpoint_url(
+    client: &crate::api::ApiClient,
+    scope: RunnerScope,
+    org: Option<String>,
+    target: &crate::target::ResolvedTarget,
+    endpoint: &str,
+) -> eyre::Result<(Option<String>, Option<String>, String)> {
+    match scope {
+        RunnerScope::Global => Ok((
+            None,
+            None,
+            client.api_v1_url(&format!("/admin/runners/{endpoint}")),
+        )),
+        RunnerScope::Org => {
+            let org = org.ok_or_else(|| eyre!("--org is required for --scope org"))?;
+            let url = client.api_v1_url(&format!(
+                "/orgs/{}/actions/runners/{endpoint}",
+                urlencoding::encode(&org)
+            ));
+            Ok((Some(org), None, url))
+        }
+        RunnerScope::Repo => {
+            let owner = target.owner.as_deref().ok_or_else(|| {
+                eyre!(
+                    "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
+                )
+            })?;
+            let name = target
+                .name
+                .as_deref()
+                .ok_or_else(|| eyre!("resolved repo is missing name"))?;
+            let repo = target
+                .repo
+                .clone()
+                .unwrap_or_else(|| format!("{owner}/{name}"));
+            let url = client.api_v1_url(&format!(
+                "/repos/{}/{}/actions/runners/{endpoint}",
+                urlencoding::encode(owner),
+                urlencoding::encode(name)
+            ));
+            Ok((None, Some(repo), url))
+        }
+        RunnerScope::User => Ok((
+            None,
+            None,
+            client.api_v1_url(&format!("/user/actions/runners/{endpoint}")),
+        )),
+    }
+}
+
 async fn run_runners(
     command: ActionsRunnersSubcommand,
     target: &crate::target::ResolvedTarget,
@@ -982,48 +1032,8 @@ async fn run_runners(
     match command {
         ActionsRunnersSubcommand::Token { scope, org, json } => {
             let scope = resolve_runner_scope(scope, org.as_deref(), target);
-
-            let (org_out, repo_out, url) = match scope {
-                RunnerScope::Global => (
-                    None,
-                    None,
-                    client.api_v1_url("/admin/runners/registration-token"),
-                ),
-                RunnerScope::Org => {
-                    let org = org.ok_or_else(|| eyre!("--org is required for --scope org"))?;
-                    let url = client.api_v1_url(&format!(
-                        "/orgs/{}/actions/runners/registration-token",
-                        urlencoding::encode(&org)
-                    ));
-                    (Some(org), None, url)
-                }
-                RunnerScope::Repo => {
-                    let owner = target.owner.as_deref().ok_or_else(|| {
-                        eyre!(
-                            "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
-                        )
-                    })?;
-                    let name = target
-                        .name
-                        .as_deref()
-                        .ok_or_else(|| eyre!("resolved repo is missing name"))?;
-                    let repo = target
-                        .repo
-                        .clone()
-                        .unwrap_or_else(|| format!("{owner}/{name}"));
-                    let url = client.api_v1_url(&format!(
-                        "/repos/{}/{}/actions/runners/registration-token",
-                        urlencoding::encode(owner),
-                        urlencoding::encode(name)
-                    ));
-                    (None, Some(repo), url)
-                }
-                RunnerScope::User => (
-                    None,
-                    None,
-                    client.api_v1_url("/user/actions/runners/registration-token"),
-                ),
-            };
+            let (org_out, repo_out, url) =
+                resolve_runner_endpoint_url(&client, scope, org, target, "registration-token")?;
 
             let reg: crate::api::RegistrationToken = client.get_json(&url).await?;
 
@@ -1075,39 +1085,8 @@ async fn run_runners(
                 )
             };
 
-            let (org_out, repo_out, base_jobs_url) = match scope {
-                RunnerScope::Global => (None, None, client.api_v1_url("/admin/runners/jobs")),
-                RunnerScope::Org => {
-                    let org = org.ok_or_else(|| eyre!("--org is required for --scope org"))?;
-                    let url = client.api_v1_url(&format!(
-                        "/orgs/{}/actions/runners/jobs",
-                        urlencoding::encode(&org)
-                    ));
-                    (Some(org), None, url)
-                }
-                RunnerScope::Repo => {
-                    let owner = target.owner.as_deref().ok_or_else(|| {
-                        eyre!(
-                            "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
-                        )
-                    })?;
-                    let name = target
-                        .name
-                        .as_deref()
-                        .ok_or_else(|| eyre!("resolved repo is missing name"))?;
-                    let repo = target
-                        .repo
-                        .clone()
-                        .unwrap_or_else(|| format!("{owner}/{name}"));
-                    let url = client.api_v1_url(&format!(
-                        "/repos/{}/{}/actions/runners/jobs",
-                        urlencoding::encode(owner),
-                        urlencoding::encode(name)
-                    ));
-                    (None, Some(repo), url)
-                }
-                RunnerScope::User => (None, None, client.api_v1_url("/user/actions/runners/jobs")),
-            };
+            let (org_out, repo_out, base_jobs_url) =
+                resolve_runner_endpoint_url(&client, scope, org, target, "jobs")?;
 
             let url = format!("{base_jobs_url}{labels_query}");
             let mut jobs: Vec<crate::api::ActionRunJob> = client.get_json(&url).await?;

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -6,7 +6,8 @@ use eyre::{eyre, Context};
 use tokio::io::AsyncWriteExt;
 
 use crate::cli::{
-    ActionsArtifactsSubcommand, ActionsCommand, ActionsLogsSubcommand, ActionsSubcommand,
+    ActionsArtifactsSubcommand, ActionsCommand, ActionsLogsSubcommand, ActionsRunnersSubcommand,
+    ActionsSubcommand, RunnerScope,
 };
 
 static SAFE_FILENAME_COMPONENT_RE: LazyLock<regex::Regex> =
@@ -19,13 +20,10 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
         args.target.remote.as_deref(),
     )?;
 
-    let repo = target.repo.ok_or_else(|| {
-        eyre!(
-            "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
-        )
-    })?;
-
     match args.command {
+        ActionsSubcommand::Runners { command } => {
+            run_runners(command, &target).await?;
+        }
         ActionsSubcommand::Trigger {
             workflow,
             git_ref,
@@ -33,6 +31,7 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
             dry_run,
             json,
         } => {
+            let repo = require_repo_owned(&target)?;
             let repo_path = repo.trim_matches('/');
             let (owner, name) = repo_path.split_once('/').ok_or_else(|| {
                 eyre!(
@@ -134,6 +133,7 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
             }
         }
         command => {
+            let repo = require_repo_owned(&target)?;
             let session = crate::session::UiSession::from_store(&target.base_url, false).await?;
 
             match command {
@@ -766,6 +766,9 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
                 ActionsSubcommand::Trigger { .. } => {
                     unreachable!("Trigger is handled before UiSession initialization")
                 }
+                ActionsSubcommand::Runners { .. } => {
+                    unreachable!("Runners is handled before UiSession initialization")
+                }
             }
         }
     }
@@ -917,6 +920,233 @@ async fn rerun_failed_jobs(
         );
         for redirect in redirects {
             println!("{redirect}");
+        }
+    }
+
+    Ok(())
+}
+
+fn require_repo_owned(target: &crate::target::ResolvedTarget) -> eyre::Result<String> {
+    target.repo.clone().ok_or_else(|| {
+        eyre!(
+            "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
+        )
+    })
+}
+
+fn runner_scope_name(scope: RunnerScope) -> &'static str {
+    match scope {
+        RunnerScope::Global => "global",
+        RunnerScope::Org => "org",
+        RunnerScope::Repo => "repo",
+        RunnerScope::User => "user",
+    }
+}
+
+fn resolve_runner_scope(
+    scope: Option<RunnerScope>,
+    org: Option<&str>,
+    target: &crate::target::ResolvedTarget,
+) -> RunnerScope {
+    if let Some(scope) = scope {
+        return scope;
+    }
+    if org.is_some() {
+        return RunnerScope::Org;
+    }
+    if target.repo.is_some() {
+        return RunnerScope::Repo;
+    }
+    RunnerScope::Global
+}
+
+fn fj_missing_api_token_error(base_url: &str) -> eyre::Report {
+    let host_key = crate::target::normalize_host_key(base_url).unwrap_or_else(|_| base_url.into());
+    let path = crate::store::keys_store_paths()
+        .map(|p| p.path.display().to_string())
+        .unwrap_or_else(|_| "%APPDATA%/Cyborus/forgejo-cli/data/keys.json".to_string());
+
+    eyre!(
+        "No Forgejo API token found for host '{host_key}'. Authenticate via `fj`:\n  fj --host {host_key} auth login\n  fj --host {host_key} auth add-key <USER>  # reads token from stdin if omitted\nToken store:\n  %APPDATA%/Cyborus/forgejo-cli/data/keys.json (Windows)\n  ~/.local/share/Cyborus/forgejo-cli/data/keys.json (Linux)\nReading: {path}"
+    )
+}
+
+async fn run_runners(
+    command: ActionsRunnersSubcommand,
+    target: &crate::target::ResolvedTarget,
+) -> eyre::Result<()> {
+    let token = crate::store::get_fj_api_token_for_base_url(&target.base_url)?
+        .ok_or_else(|| fj_missing_api_token_error(&target.base_url))?;
+    let client = crate::api::ApiClient::new(&target.base_url, &token)?;
+
+    match command {
+        ActionsRunnersSubcommand::Token { scope, org, json } => {
+            let scope = resolve_runner_scope(scope, org.as_deref(), target);
+
+            let (org_out, repo_out, url) = match scope {
+                RunnerScope::Global => (
+                    None,
+                    None,
+                    client.api_v1_url("/admin/runners/registration-token"),
+                ),
+                RunnerScope::Org => {
+                    let org = org.ok_or_else(|| eyre!("--org is required for --scope org"))?;
+                    let url = client.api_v1_url(&format!(
+                        "/orgs/{}/actions/runners/registration-token",
+                        urlencoding::encode(&org)
+                    ));
+                    (Some(org), None, url)
+                }
+                RunnerScope::Repo => {
+                    let owner = target.owner.as_deref().ok_or_else(|| {
+                        eyre!(
+                            "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
+                        )
+                    })?;
+                    let name = target
+                        .name
+                        .as_deref()
+                        .ok_or_else(|| eyre!("resolved repo is missing name"))?;
+                    let repo = target
+                        .repo
+                        .clone()
+                        .unwrap_or_else(|| format!("{owner}/{name}"));
+                    let url = client.api_v1_url(&format!(
+                        "/repos/{}/{}/actions/runners/registration-token",
+                        urlencoding::encode(owner),
+                        urlencoding::encode(name)
+                    ));
+                    (None, Some(repo), url)
+                }
+                RunnerScope::User => (
+                    None,
+                    None,
+                    client.api_v1_url("/user/actions/runners/registration-token"),
+                ),
+            };
+
+            let reg: crate::api::RegistrationToken = client.get_json(&url).await?;
+
+            if json {
+                let payload = serde_json::json!({
+                    "baseUrl": target.base_url,
+                    "scope": runner_scope_name(scope),
+                    "org": org_out,
+                    "repo": repo_out,
+                    "token": reg.token,
+                });
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                println!("{}", reg.token);
+            }
+        }
+        ActionsRunnersSubcommand::Jobs {
+            scope,
+            org,
+            label,
+            waiting,
+            header,
+            no_header,
+            json,
+        } => {
+            let scope = resolve_runner_scope(scope, org.as_deref(), target);
+
+            let labels = {
+                let mut out = Vec::with_capacity(label.len());
+                for l in label {
+                    let trimmed = l.trim();
+                    if trimmed.is_empty() {
+                        return Err(eyre!("--label cannot be empty"));
+                    }
+                    out.push(trimmed.to_string());
+                }
+                out
+            };
+            let labels_query = if labels.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "?labels={}",
+                    labels
+                        .iter()
+                        .map(|l| urlencoding::encode(l).into_owned())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            };
+
+            let (org_out, repo_out, base_jobs_url) = match scope {
+                RunnerScope::Global => (None, None, client.api_v1_url("/admin/runners/jobs")),
+                RunnerScope::Org => {
+                    let org = org.ok_or_else(|| eyre!("--org is required for --scope org"))?;
+                    let url = client.api_v1_url(&format!(
+                        "/orgs/{}/actions/runners/jobs",
+                        urlencoding::encode(&org)
+                    ));
+                    (Some(org), None, url)
+                }
+                RunnerScope::Repo => {
+                    let owner = target.owner.as_deref().ok_or_else(|| {
+                        eyre!(
+                            "Repo could not be resolved. Pass --repo owner/name or run inside a git repo with a Forgejo remote."
+                        )
+                    })?;
+                    let name = target
+                        .name
+                        .as_deref()
+                        .ok_or_else(|| eyre!("resolved repo is missing name"))?;
+                    let repo = target
+                        .repo
+                        .clone()
+                        .unwrap_or_else(|| format!("{owner}/{name}"));
+                    let url = client.api_v1_url(&format!(
+                        "/repos/{}/{}/actions/runners/jobs",
+                        urlencoding::encode(owner),
+                        urlencoding::encode(name)
+                    ));
+                    (None, Some(repo), url)
+                }
+                RunnerScope::User => (None, None, client.api_v1_url("/user/actions/runners/jobs")),
+            };
+
+            let url = format!("{base_jobs_url}{labels_query}");
+            let mut jobs: Vec<crate::api::ActionRunJob> = client.get_json(&url).await?;
+
+            if waiting {
+                jobs.retain(|j| {
+                    j.status
+                        .as_deref()
+                        .is_some_and(|s| s.eq_ignore_ascii_case("waiting"))
+                });
+            }
+
+            if json {
+                let payload = serde_json::json!({
+                    "baseUrl": target.base_url,
+                    "scope": runner_scope_name(scope),
+                    "org": org_out,
+                    "repo": repo_out,
+                    "labels": labels,
+                    "waitingOnly": waiting,
+                    "jobs": jobs,
+                });
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+                return Ok(());
+            }
+
+            let show_header = crate::output::should_print_header(header, no_header);
+            let headers = vec!["Id", "Status", "Name", "RunsOn"];
+            let mut rows = Vec::with_capacity(jobs.len());
+            for j in jobs {
+                let runs_on = j.runs_on_display();
+                rows.push(vec![
+                    j.id.to_string(),
+                    j.status.unwrap_or_else(|| "?".to_string()),
+                    j.name,
+                    runs_on,
+                ]);
+            }
+            crate::output::print_table(&headers, &rows, show_header);
         }
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,137 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use eyre::{eyre, Context};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
+#[derive(Clone)]
+pub struct ApiClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl ApiClient {
+    pub fn new(base_url: &str, token: &str) -> eyre::Result<Self> {
+        let base_url = crate::target::normalize_base_url(base_url)?;
+        let base_url = base_url.trim_end_matches('/').to_string();
+
+        let mut headers = HeaderMap::new();
+        let auth_value = HeaderValue::from_str(&format!("token {token}"))
+            .wrap_err("invalid api token for Authorization header")?;
+        headers.insert(AUTHORIZATION, auth_value);
+
+        let client = reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(Duration::from_secs(60))
+            .default_headers(headers)
+            .build()
+            .wrap_err("failed to build http client")?;
+
+        Ok(Self { base_url, client })
+    }
+
+    pub fn api_v1_url(&self, path: &str) -> String {
+        let path = if path.starts_with('/') {
+            path.to_string()
+        } else {
+            format!("/{path}")
+        };
+        format!("{}/api/v1{path}", self.base_url)
+    }
+
+    pub async fn get_json<T: DeserializeOwned>(&self, url: &str) -> eyre::Result<T> {
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .wrap_err_with(|| format!("GET {url} failed"))?;
+
+        let status = resp.status();
+        let body = resp
+            .bytes()
+            .await
+            .wrap_err_with(|| format!("failed to read response body from GET {url}"))?;
+
+        if !status.is_success() {
+            let preview = String::from_utf8_lossy(&body)
+                .chars()
+                .take(4096)
+                .collect::<String>();
+            return Err(eyre!("GET {url} failed: HTTP {status} body={preview}"));
+        }
+
+        serde_json::from_slice::<T>(&body).wrap_err_with(|| {
+            let preview = String::from_utf8_lossy(&body)
+                .chars()
+                .take(4096)
+                .collect::<String>();
+            format!("failed to decode JSON from GET {url}: body={preview}")
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RegistrationToken {
+    pub token: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct ActionRunJob {
+    pub id: i64,
+
+    #[serde(default)]
+    pub name: String,
+
+    pub status: Option<String>,
+
+    #[serde(rename = "runs_on", default)]
+    pub runs_on: Vec<String>,
+
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl ActionRunJob {
+    pub fn runs_on_display(&self) -> String {
+        self.runs_on.join(",")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registration_token_deserializes() {
+        let raw = r#"{ "token": "abc" }"#;
+        let tok: RegistrationToken = serde_json::from_str(raw).unwrap();
+        assert_eq!(tok.token, "abc");
+    }
+
+    #[test]
+    fn runner_jobs_deserialize_minimal_list() {
+        let raw = r#"
+[
+  {
+    "id": 1,
+    "status": "waiting",
+    "name": "build",
+    "runs_on": ["self-hosted", "linux"]
+  }
+]
+"#;
+
+        let jobs: Vec<ActionRunJob> = serde_json::from_str(raw).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, 1);
+        assert_eq!(jobs[0].status.as_deref(), Some("waiting"));
+        assert_eq!(jobs[0].name, "build");
+        assert_eq!(jobs[0].runs_on, vec!["self-hosted", "linux"]);
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -59,19 +59,17 @@ impl ApiClient {
             .wrap_err_with(|| format!("failed to read response body from GET {url}"))?;
 
         if !status.is_success() {
-            let preview = String::from_utf8_lossy(&body)
-                .chars()
-                .take(4096)
-                .collect::<String>();
-            return Err(eyre!("GET {url} failed: HTTP {status} body={preview}"));
+            return Err(eyre!(
+                "GET {url} failed: HTTP {status} (body_length={})",
+                body.len()
+            ));
         }
 
         serde_json::from_slice::<T>(&body).wrap_err_with(|| {
-            let preview = String::from_utf8_lossy(&body)
-                .chars()
-                .take(4096)
-                .collect::<String>();
-            format!("failed to decode JSON from GET {url}: body={preview}")
+            format!(
+                "failed to decode JSON from GET {url} (body_length={})",
+                body.len()
+            )
         })
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::num::{NonZeroU32, NonZeroU64};
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(name = "fj-ex", version, about)]
@@ -252,6 +252,11 @@ pub enum ActionsSubcommand {
         #[arg(long, help = "Print JSON output.")]
         json: bool,
     },
+    /// Runner registration tokens and queued jobs (REST API; uses `fj`'s stored API token).
+    Runners {
+        #[command(subcommand)]
+        command: ActionsRunnersSubcommand,
+    },
     /// Smoke test for Actions access (useful for debugging auth/connectivity/log downloads).
     #[command(name = "smoke-test")]
     SmokeTest(ActionsSmokeTestCommand),
@@ -414,4 +419,60 @@ pub struct SmokeTestCommand {
 
     #[command(flatten)]
     pub opts: ActionsSmokeTestCommand,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerScope {
+    Global,
+    Org,
+    Repo,
+    User,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ActionsRunnersSubcommand {
+    /// Print a runner registration token.
+    Token {
+        /// Runner scope (default: org if --org is set, else repo if resolved, else global).
+        #[arg(long, value_enum)]
+        scope: Option<RunnerScope>,
+
+        /// Org name (required for --scope org).
+        #[arg(long)]
+        org: Option<String>,
+
+        /// Print JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List runner jobs (useful for diagnosing "waiting" and label mismatches).
+    Jobs {
+        /// Runner scope (default: org if --org is set, else repo if resolved, else global).
+        #[arg(long, value_enum)]
+        scope: Option<RunnerScope>,
+
+        /// Org name (required for --scope org).
+        #[arg(long)]
+        org: Option<String>,
+
+        /// Filter by runner label (repeatable; sent as labels=a,b).
+        #[arg(long, value_name = "LABEL")]
+        label: Vec<String>,
+
+        /// Show only jobs with status == "waiting" (case-insensitive).
+        #[arg(long)]
+        waiting: bool,
+
+        /// Always print the header row (even when piping).
+        #[arg(long)]
+        header: bool,
+
+        /// Never print the header row.
+        #[arg(long, conflicts_with = "header")]
+        no_header: bool,
+
+        /// Print JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod api;
 mod auth;
 mod cli;
 mod html;

--- a/src/store.rs
+++ b/src/store.rs
@@ -29,6 +29,90 @@ pub fn ui_creds_store_paths() -> eyre::Result<StorePaths> {
     Ok(StorePaths { dir, path })
 }
 
+pub fn keys_store_paths() -> eyre::Result<StorePaths> {
+    let app_data = std::env::var_os("APPDATA")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| directories::BaseDirs::new().map(|d| d.data_dir().to_path_buf()))
+        .ok_or_else(|| eyre!("unable to locate AppData directory"))?;
+
+    let dir = app_data.join("Cyborus").join("forgejo-cli").join("data");
+    let path = dir.join("keys.json");
+    Ok(StorePaths { dir, path })
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct KeysStore {
+    #[serde(default)]
+    pub hosts: BTreeMap<String, KeysHostEntry>,
+
+    #[serde(default)]
+    pub aliases: BTreeMap<String, String>,
+
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct KeysHostEntry {
+    pub token: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+pub fn read_keys_store() -> eyre::Result<KeysStore> {
+    let store_path = keys_store_paths()?.path;
+    if !store_path.is_file() {
+        return Ok(KeysStore::default());
+    }
+
+    let raw = std::fs::read_to_string(&store_path)
+        .wrap_err_with(|| format!("failed to read keys store at '{}'", store_path.display()))?;
+    if raw.trim().is_empty() {
+        return Ok(KeysStore::default());
+    }
+
+    serde_json::from_str::<KeysStore>(&raw).wrap_err_with(|| {
+        format!(
+            "invalid keys store JSON at '{}'. Re-run `fj auth login` to recreate.",
+            store_path.display()
+        )
+    })
+}
+
+pub fn get_fj_api_token_for_base_url(base_url: &str) -> eyre::Result<Option<String>> {
+    let keys = read_keys_store()?;
+    get_fj_api_token_for_base_url_from_store(&keys, base_url)
+}
+
+fn get_fj_api_token_for_base_url_from_store(
+    keys: &KeysStore,
+    base_url: &str,
+) -> eyre::Result<Option<String>> {
+    let mut host_key = crate::target::normalize_host_key(base_url)?;
+    let mut seen = std::collections::HashSet::new();
+
+    // Follow aliases a few times to avoid accidental loops.
+    for _ in 0..10 {
+        if !seen.insert(host_key.clone()) {
+            return Ok(None);
+        }
+
+        if let Some(entry) = keys.hosts.get(&host_key) {
+            return Ok(entry.token.clone());
+        }
+
+        let Some(next) = keys.aliases.get(&host_key) else {
+            return Ok(None);
+        };
+        host_key = crate::target::normalize_host_key(next)
+            .wrap_err_with(|| format!("invalid keys.json alias target '{next}'"))?;
+    }
+
+    Ok(None)
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct StoreEntry {
     #[serde(rename = "baseUrl")]
@@ -419,5 +503,41 @@ mod tests {
             Some("https://forge.example.com")
         );
         assert_eq!(repaired["other"].base_url.as_deref(), Some("https://other"));
+    }
+
+    #[test]
+    fn fj_keys_store_token_lookup_by_normalized_host_key() {
+        let raw = r#"
+{
+  "hosts": {
+    "forge.example.com:3000": { "token": "abc" }
+  }
+}
+"#;
+
+        let keys: KeysStore = serde_json::from_str(raw).unwrap();
+        let token =
+            get_fj_api_token_for_base_url_from_store(&keys, "https://forge.example.com:3000")
+                .unwrap();
+        assert_eq!(token.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn fj_keys_store_token_lookup_follows_aliases() {
+        let raw = r#"
+{
+  "hosts": {
+    "forge.example.com": { "token": "real-token" }
+  },
+  "aliases": {
+    "alias.example.com": "forge.example.com"
+  }
+}
+"#;
+
+        let keys: KeysStore = serde_json::from_str(raw).unwrap();
+        let token =
+            get_fj_api_token_for_base_url_from_store(&keys, "https://alias.example.com").unwrap();
+        assert_eq!(token.as_deref(), Some("real-token"));
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -17,12 +17,16 @@ pub struct StorePaths {
     pub path: PathBuf,
 }
 
-pub fn ui_creds_store_paths() -> eyre::Result<StorePaths> {
-    let app_data = std::env::var_os("APPDATA")
+fn app_data_base_dir() -> eyre::Result<PathBuf> {
+    std::env::var_os("APPDATA")
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)
         .or_else(|| directories::BaseDirs::new().map(|d| d.data_dir().to_path_buf()))
-        .ok_or_else(|| eyre!("unable to locate AppData directory"))?;
+        .ok_or_else(|| eyre!("unable to locate AppData directory"))
+}
+
+pub fn ui_creds_store_paths() -> eyre::Result<StorePaths> {
+    let app_data = app_data_base_dir()?;
 
     let dir = app_data.join("Cyborus").join("forgejo-cli").join("data");
     let path = dir.join("ui-creds.json");
@@ -30,11 +34,7 @@ pub fn ui_creds_store_paths() -> eyre::Result<StorePaths> {
 }
 
 pub fn keys_store_paths() -> eyre::Result<StorePaths> {
-    let app_data = std::env::var_os("APPDATA")
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .or_else(|| directories::BaseDirs::new().map(|d| d.data_dir().to_path_buf()))
-        .ok_or_else(|| eyre!("unable to locate AppData directory"))?;
+    let app_data = app_data_base_dir()?;
 
     let dir = app_data.join("Cyborus").join("forgejo-cli").join("data");
     let path = dir.join("keys.json");

--- a/tests/e2e_forgejo_docker.rs
+++ b/tests/e2e_forgejo_docker.rs
@@ -8,6 +8,7 @@ use std::{
 
 use eyre::{eyre, Context, Result};
 use serde_json::Value;
+use url::Url;
 
 const FORGEJO_IMAGE: &str = "codeberg.org/forgejo/forgejo:14.0.2";
 const FORGEJO_IMAGE_11_0_10: &str = "codeberg.org/forgejo/forgejo:11.0.10";
@@ -83,6 +84,57 @@ async fn run_e2e(forgejo_image: &str, version_label: &str) -> Result<()> {
 
     let fj_ex = fj_ex_bin()?;
 
+    // Runners (REST API) requires `fj`'s stored API token. Ensure missing-token UX is clear.
+    let missing_token_out = fj_ex_cmd_expect_failure(
+        &fj_ex,
+        &appdata_dir,
+        &[
+            "actions", "--host", &base_url, "runners", "token", "--scope", "global",
+        ],
+        None,
+    )?;
+    assert!(
+        missing_token_out
+            .stderr
+            .contains("No Forgejo API token found"),
+        "expected missing token error, got stderr:\n{}",
+        missing_token_out.stderr
+    );
+    assert!(
+        missing_token_out.stderr.contains("fj --host"),
+        "expected fj auth instructions, got stderr:\n{}",
+        missing_token_out.stderr
+    );
+    assert!(
+        missing_token_out.stderr.contains("keys.json"),
+        "expected keys.json path mention, got stderr:\n{}",
+        missing_token_out.stderr
+    );
+
+    // Create an API token and write it to the same keys.json store that `fj` uses.
+    let fj_api_token = docker_stdout(&[
+        "exec",
+        "-u",
+        "git",
+        &forgejo_name,
+        "forgejo",
+        "admin",
+        "user",
+        "generate-access-token",
+        "--username",
+        username,
+        "--token-name",
+        "fj-ex-e2e",
+        "--scopes",
+        "all",
+        "--raw",
+    ])
+    .wrap_err("failed to generate api token")?;
+    if fj_api_token.trim().is_empty() {
+        return Err(eyre!("api token was empty"));
+    }
+    write_fj_keys_json(&appdata_dir, &base_url, fj_api_token.trim())?;
+
     // Login (non-interactive)
     fj_ex_cmd(
         &fj_ex,
@@ -127,6 +179,65 @@ async fn run_e2e(forgejo_image: &str, version_label: &str) -> Result<()> {
     let show_json: Value = serde_json::from_str(&show_out.stdout)?;
     assert_eq!(show_json["username"], username);
     assert_eq!(show_json["hasPassword"], true);
+
+    // Runner registration tokens (global/repo/user)
+    let token_repo_out = fj_ex_cmd(
+        &fj_ex,
+        &appdata_dir,
+        &[
+            "actions", "--host", &base_url, "--repo", &repo, "runners", "token", "--json",
+        ],
+        None,
+    )?;
+    let token_repo_json: Value = serde_json::from_str(&token_repo_out.stdout)?;
+    assert_eq!(token_repo_json["baseUrl"], base_url);
+    assert_eq!(token_repo_json["scope"], "repo");
+    assert_eq!(token_repo_json["repo"], repo);
+    assert!(
+        token_repo_json["token"]
+            .as_str()
+            .is_some_and(|s| !s.trim().is_empty()),
+        "expected repo token, got: {}",
+        token_repo_out.stdout
+    );
+
+    let token_global_out = fj_ex_cmd(
+        &fj_ex,
+        &appdata_dir,
+        &[
+            "actions", "--host", &base_url, "runners", "token", "--scope", "global", "--json",
+        ],
+        None,
+    )?;
+    let token_global_json: Value = serde_json::from_str(&token_global_out.stdout)?;
+    assert_eq!(token_global_json["baseUrl"], base_url);
+    assert_eq!(token_global_json["scope"], "global");
+    assert!(
+        token_global_json["token"]
+            .as_str()
+            .is_some_and(|s| !s.trim().is_empty()),
+        "expected global token, got: {}",
+        token_global_out.stdout
+    );
+
+    let token_user_out = fj_ex_cmd(
+        &fj_ex,
+        &appdata_dir,
+        &[
+            "actions", "--host", &base_url, "runners", "token", "--scope", "user", "--json",
+        ],
+        None,
+    )?;
+    let token_user_json: Value = serde_json::from_str(&token_user_out.stdout)?;
+    assert_eq!(token_user_json["baseUrl"], base_url);
+    assert_eq!(token_user_json["scope"], "user");
+    assert!(
+        token_user_json["token"]
+            .as_str()
+            .is_some_and(|s| !s.trim().is_empty()),
+        "expected user token, got: {}",
+        token_user_out.stdout
+    );
 
     // Wait for the first run to exist and finish.
     let run_index = wait_for_first_run(&fj_ex, &appdata_dir, &base_url, &repo).await?;
@@ -342,6 +453,36 @@ async fn run_e2e(forgejo_image: &str, version_label: &str) -> Result<()> {
         None,
     )?;
     assert!(smoke_out.stdout.lines().any(|l| l.trim() == "OK"));
+
+    // Trigger a workflow with a mismatched runs-on label to ensure runner jobs can be listed/filtered.
+    let _trigger_waiting_out = fj_ex_cmd(
+        &fj_ex,
+        &appdata_dir,
+        &[
+            "actions",
+            "--host",
+            &base_url,
+            "--repo",
+            &repo,
+            "trigger",
+            "--workflow",
+            "e2e-waiting.yml",
+            "--ref",
+            "main",
+            "--json",
+        ],
+        None,
+    )?;
+    let waiting_jobs_json =
+        wait_for_waiting_runner_jobs(&fj_ex, &appdata_dir, &base_url, &repo, "missing-label")
+            .await?;
+    assert_eq!(waiting_jobs_json["baseUrl"], base_url);
+    assert_eq!(waiting_jobs_json["scope"], "repo");
+    assert_eq!(waiting_jobs_json["repo"], repo);
+    assert_eq!(waiting_jobs_json["waitingOnly"], true);
+    assert!(waiting_jobs_json["jobs"]
+        .as_array()
+        .is_some_and(|a| !a.is_empty()));
 
     // Logout should remove the entry.
     fj_ex_cmd(
@@ -688,6 +829,20 @@ jobs:
 "#,
     )
     .wrap_err("failed to write workflow")?;
+    fs::write(
+        wf_dir.join("e2e-waiting.yml"),
+        r#"name: fj-ex e2e waiting
+on:
+  workflow_dispatch:
+
+jobs:
+  waiting:
+    runs-on: missing-label
+    steps:
+      - run: echo "fj-ex-e2e: waiting"
+"#,
+    )
+    .wrap_err("failed to write waiting workflow")?;
     fs::write(repo_dir.join("README.md"), "# fj-ex e2e\n").wrap_err("failed to write readme")?;
 
     git(repo_dir, &["init", "-b", "main"]).wrap_err("git init failed")?;
@@ -759,7 +914,6 @@ fn fj_ex_bin() -> Result<PathBuf> {
 
 struct FjOut {
     stdout: String,
-    #[allow(dead_code)]
     stderr: String,
 }
 
@@ -810,6 +964,83 @@ fn fj_ex_cmd(
     Ok(FjOut { stdout, stderr })
 }
 
+fn fj_ex_cmd_expect_failure(
+    bin: &Path,
+    appdata_dir: &Path,
+    args: &[&str],
+    stdin: Option<Vec<u8>>,
+) -> Result<FjOut> {
+    let mut cmd = Command::new(bin);
+    cmd.args(args)
+        .env("APPDATA", appdata_dir)
+        .env("RUST_BACKTRACE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .wrap_err_with(|| format!("failed to spawn fj-ex {}", args.join(" ")))?;
+
+    if let Some(input) = stdin {
+        use std::io::Write;
+        let Some(mut s) = child.stdin.take() else {
+            return Err(eyre!("failed to open fj-ex stdin pipe"));
+        };
+        s.write_all(&input)
+            .wrap_err("failed to write to fj-ex stdin")?;
+    }
+
+    let output: Output = child
+        .wait_with_output()
+        .wrap_err("failed to wait for fj-ex")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if output.status.success() {
+        return Err(eyre!(
+            "fj-ex {} unexpectedly succeeded:\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            stdout,
+            stderr
+        ));
+    }
+
+    Ok(FjOut { stdout, stderr })
+}
+
+fn write_fj_keys_json(appdata_dir: &Path, base_url: &str, token: &str) -> Result<PathBuf> {
+    let host_key = host_key_from_base_url(base_url)?;
+
+    let dir = appdata_dir.join("Cyborus").join("forgejo-cli").join("data");
+    fs::create_dir_all(&dir).wrap_err("failed to create keys store dir")?;
+    let path = dir.join("keys.json");
+
+    let json = serde_json::json!({
+        "hosts": {
+            host_key: {
+                "token": token,
+            }
+        },
+        "aliases": {},
+    });
+
+    fs::write(&path, serde_json::to_vec_pretty(&json)?).wrap_err("failed to write keys.json")?;
+    Ok(path)
+}
+
+fn host_key_from_base_url(base_url: &str) -> Result<String> {
+    let url = Url::parse(base_url).wrap_err("invalid base url")?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| eyre!("base url missing host"))?;
+    if let Some(port) = url.port() {
+        return Ok(format!("{host}:{port}"));
+    }
+    Ok(host.to_string())
+}
+
 async fn wait_for_first_run(
     bin: &Path,
     appdata_dir: &Path,
@@ -858,6 +1089,70 @@ async fn wait_for_first_run(
         }
 
         tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+async fn wait_for_waiting_runner_jobs(
+    bin: &Path,
+    appdata_dir: &Path,
+    base_url: &str,
+    repo: &str,
+    label: &str,
+) -> Result<Value> {
+    let start = Instant::now();
+    let timeout = Duration::from_secs(120);
+
+    loop {
+        if start.elapsed() > timeout {
+            return Err(eyre!("timeout waiting for waiting runner jobs to appear"));
+        }
+
+        let out = fj_ex_cmd(
+            bin,
+            appdata_dir,
+            &[
+                "actions",
+                "--host",
+                base_url,
+                "--repo",
+                repo,
+                "runners",
+                "jobs",
+                "--waiting",
+                "--label",
+                label,
+                "--json",
+            ],
+            None,
+        );
+        let out = match out {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("warn: failed to list runner jobs (will retry): {e}");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        };
+
+        let json: Value = match serde_json::from_str(&out.stdout) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("warn: failed to parse runner jobs json (will retry): {e}");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        };
+
+        let Some(jobs) = json["jobs"].as_array() else {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            continue;
+        };
+        if jobs.is_empty() {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            continue;
+        }
+
+        return Ok(json);
     }
 }
 

--- a/tests/e2e_forgejo_docker.rs
+++ b/tests/e2e_forgejo_docker.rs
@@ -918,11 +918,12 @@ struct FjOut {
     stderr: String,
 }
 
-fn fj_ex_cmd(
+fn fj_ex_cmd_with_expectation(
     bin: &Path,
     appdata_dir: &Path,
     args: &[&str],
     stdin: Option<Vec<u8>>,
+    expect_success: bool,
 ) -> Result<FjOut> {
     let mut cmd = Command::new(bin);
     cmd.args(args)
@@ -952,7 +953,7 @@ fn fj_ex_cmd(
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    if !output.status.success() {
+    if expect_success && !output.status.success() {
         return Err(eyre!(
             "fj-ex {} failed (exit={}):\nstdout:\n{}\nstderr:\n{}",
             args.join(" "),
@@ -961,45 +962,7 @@ fn fj_ex_cmd(
             stderr
         ));
     }
-
-    Ok(FjOut { stdout, stderr })
-}
-
-fn fj_ex_cmd_expect_failure(
-    bin: &Path,
-    appdata_dir: &Path,
-    args: &[&str],
-    stdin: Option<Vec<u8>>,
-) -> Result<FjOut> {
-    let mut cmd = Command::new(bin);
-    cmd.args(args)
-        .env("APPDATA", appdata_dir)
-        .env("RUST_BACKTRACE", "1")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let mut child = cmd
-        .spawn()
-        .wrap_err_with(|| format!("failed to spawn fj-ex {}", args.join(" ")))?;
-
-    if let Some(input) = stdin {
-        use std::io::Write;
-        let Some(mut s) = child.stdin.take() else {
-            return Err(eyre!("failed to open fj-ex stdin pipe"));
-        };
-        s.write_all(&input)
-            .wrap_err("failed to write to fj-ex stdin")?;
-    }
-
-    let output: Output = child
-        .wait_with_output()
-        .wrap_err("failed to wait for fj-ex")?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    if output.status.success() {
+    if !expect_success && output.status.success() {
         return Err(eyre!(
             "fj-ex {} unexpectedly succeeded:\nstdout:\n{}\nstderr:\n{}",
             args.join(" "),
@@ -1009,6 +972,24 @@ fn fj_ex_cmd_expect_failure(
     }
 
     Ok(FjOut { stdout, stderr })
+}
+
+fn fj_ex_cmd(
+    bin: &Path,
+    appdata_dir: &Path,
+    args: &[&str],
+    stdin: Option<Vec<u8>>,
+) -> Result<FjOut> {
+    fj_ex_cmd_with_expectation(bin, appdata_dir, args, stdin, true)
+}
+
+fn fj_ex_cmd_expect_failure(
+    bin: &Path,
+    appdata_dir: &Path,
+    args: &[&str],
+    stdin: Option<Vec<u8>>,
+) -> Result<FjOut> {
+    fj_ex_cmd_with_expectation(bin, appdata_dir, args, stdin, false)
 }
 
 fn write_fj_keys_json(appdata_dir: &Path, base_url: &str, token: &str) -> Result<PathBuf> {

--- a/tests/e2e_forgejo_docker.rs
+++ b/tests/e2e_forgejo_docker.rs
@@ -839,7 +839,8 @@ jobs:
   waiting:
     runs-on: missing-label
     steps:
-      - run: echo "fj-ex-e2e: waiting"
+      - run: |
+          echo "fj-ex-e2e: waiting"
 "#,
     )
     .wrap_err("failed to write waiting workflow")?;


### PR DESCRIPTION
Adds j-ex actions runners token|jobs via Forgejo REST API and reuses the API token stored by j (keys.json) — no new auth flags/env fallbacks.

- Supports scopes: global/org/repo/user (with default resolution)
- Runner jobs listing supports --label and --waiting
- Clear missing-token guidance pointing users to j auth login / j auth add-key
- CI e2e updated to cover runners token/jobs + missing-token UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `actions runners` command:
    - `token`: retrieve registration tokens (Global/Org/Repo/User) with JSON or plain output
    - `jobs`: list queued runner jobs, filter by label and waiting state; supports JSON output
  * Automatic API token lookup via keys.json for seamless non-interactive authentication

* **Documentation**
  * Quickstart examples, credential/keys.json paths (Windows/Linux) and command usage added

* **Tests**
  * End-to-end coverage for runner token and waiting-jobs flows added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->