### PR TITLE
feat: add Unix socket support for http+unix:// URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
           FJ_EX_E2E: "1"
         run: cargo test --locked --test e2e_forgejo_docker -- --ignored --test-threads=1
 
+      - name: Run Unix socket tests
+        env:
+          FJ_EX_UNIX_SOCKET_TEST: "1"
+        run: cargo test --locked --test unix_socket_test -- --ignored --test-threads=1
+
   publish:
     needs: [test, e2e]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "eyre",
  "git2",
  "html-escape",
+ "libc",
  "regex",
  "reqwest",
  "reqwest_cookie_store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ urlencoding = "2.1.3"
 
 [dev-dependencies]
 tempfile = "3.20.0"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -48,9 +48,17 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
             let dispatch_ref = normalize_dispatch_ref(&git_ref);
             let inputs = parse_workflow_inputs(&input)?;
 
+            // Convert http+unix:// URLs to http://localhost for HTTP requests
+            // (the Unix socket transport is configured separately via builder.unix_socket)
+            let request_base = if target.base_url.starts_with("http+unix://") {
+                "http://localhost"
+            } else {
+                target.base_url.trim_end_matches('/')
+            };
+
             let url = format!(
                 "{}/api/v1/repos/{}/{}/actions/workflows/{}/dispatches",
-                target.base_url.trim_end_matches('/'),
+                request_base,
                 urlencoding::encode(owner),
                 urlencoding::encode(name),
                 urlencoding::encode(workflow)

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -134,7 +134,7 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
         }
         command => {
             let repo = require_repo_owned(&target)?;
-            let session = crate::session::UiSession::from_store(&target.base_url, false).await?;
+            let session = crate::session::UiSession::from_store_with_socket(&target.base_url, false, target.unix_socket.as_deref()).await?;
 
             match command {
                 ActionsSubcommand::Workflows { page, limit, json } => {
@@ -1027,7 +1027,7 @@ async fn run_runners(
 ) -> eyre::Result<()> {
     let token = crate::store::get_fj_api_token_for_base_url(&target.base_url)?
         .ok_or_else(|| fj_missing_api_token_error(&target.base_url))?;
-    let client = crate::api::ApiClient::new(&target.base_url, &token)?;
+    let client = crate::api::ApiClient::new_with_socket(&target.base_url, &token, target.unix_socket.as_deref())?;
 
     match command {
         ActionsRunnersSubcommand::Token { scope, org, json } => {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -90,15 +90,20 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
                     )
                 })?;
 
-            let client = reqwest::Client::builder()
+            let mut builder = reqwest::Client::builder()
                 .user_agent(concat!(
                     env!("CARGO_PKG_NAME"),
                     "/",
                     env!("CARGO_PKG_VERSION")
                 ))
-                .timeout(std::time::Duration::from_secs(60))
-                .build()
-                .wrap_err("failed to build http client")?;
+                .timeout(std::time::Duration::from_secs(60));
+
+            #[cfg(unix)]
+            if let Some(socket_path) = target.unix_socket.as_deref() {
+                builder = builder.unix_socket(socket_path);
+            }
+
+            let client = builder.build().wrap_err("failed to build http client")?;
 
             let resp = client
                 .post(&url)
@@ -134,7 +139,12 @@ pub async fn run(args: ActionsCommand) -> eyre::Result<()> {
         }
         command => {
             let repo = require_repo_owned(&target)?;
-            let session = crate::session::UiSession::from_store_with_socket(&target.base_url, false, target.unix_socket.as_deref()).await?;
+            let session = crate::session::UiSession::from_store_with_socket(
+                &target.base_url,
+                false,
+                target.unix_socket.as_deref(),
+            )
+            .await?;
 
             match command {
                 ActionsSubcommand::Workflows { page, limit, json } => {
@@ -1027,7 +1037,11 @@ async fn run_runners(
 ) -> eyre::Result<()> {
     let token = crate::store::get_fj_api_token_for_base_url(&target.base_url)?
         .ok_or_else(|| fj_missing_api_token_error(&target.base_url))?;
-    let client = crate::api::ApiClient::new_with_socket(&target.base_url, &token, target.unix_socket.as_deref())?;
+    let client = crate::api::ApiClient::new_with_socket(
+        &target.base_url,
+        &token,
+        target.unix_socket.as_deref(),
+    )?;
 
     match command {
         ActionsRunnersSubcommand::Token { scope, org, json } => {

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,7 +21,11 @@ impl ApiClient {
         Self::new_with_socket(base_url, token, None)
     }
 
-    pub fn new_with_socket(base_url: &str, token: &str, unix_socket: Option<&Path>) -> eyre::Result<Self> {
+    pub fn new_with_socket(
+        base_url: &str,
+        token: &str,
+        unix_socket: Option<&Path>,
+    ) -> eyre::Result<Self> {
         let base_url = crate::target::normalize_base_url(base_url)?;
         let base_url = base_url.trim_end_matches('/').to_string();
 
@@ -40,9 +44,7 @@ impl ApiClient {
             builder = builder.unix_socket(socket_path);
         }
 
-        let client = builder
-            .build()
-            .wrap_err("failed to build http client")?;
+        let client = builder.build().wrap_err("failed to build http client")?;
 
         Ok(Self { base_url, client })
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::time::Duration;
 
 use eyre::{eyre, Context};
@@ -17,6 +18,10 @@ pub struct ApiClient {
 
 impl ApiClient {
     pub fn new(base_url: &str, token: &str) -> eyre::Result<Self> {
+        Self::new_with_socket(base_url, token, None)
+    }
+
+    pub fn new_with_socket(base_url: &str, token: &str, unix_socket: Option<&Path>) -> eyre::Result<Self> {
         let base_url = crate::target::normalize_base_url(base_url)?;
         let base_url = base_url.trim_end_matches('/').to_string();
 
@@ -25,10 +30,17 @@ impl ApiClient {
             .wrap_err("invalid api token for Authorization header")?;
         headers.insert(AUTHORIZATION, auth_value);
 
-        let client = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .timeout(Duration::from_secs(60))
-            .default_headers(headers)
+            .default_headers(headers);
+
+        #[cfg(unix)]
+        if let Some(socket_path) = unix_socket {
+            builder = builder.unix_socket(socket_path);
+        }
+
+        let client = builder
             .build()
             .wrap_err("failed to build http client")?;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -55,7 +55,16 @@ impl ApiClient {
         } else {
             format!("/{path}")
         };
-        format!("{}/api/v1{path}", self.base_url)
+
+        // Convert http+unix:// URLs to http://localhost for HTTP requests
+        // (the Unix socket transport is configured separately via builder.unix_socket)
+        let request_base = if self.base_url.starts_with("http+unix://") {
+            "http://localhost".to_string()
+        } else {
+            self.base_url.clone()
+        };
+
+        format!("{}/api/v1{path}", request_base)
     }
 
     pub async fn get_json<T: DeserializeOwned>(&self, url: &str) -> eyre::Result<T> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -58,7 +58,11 @@ async fn run_status(args: AuthStatusCommand) -> eyre::Result<()> {
     let mut relogged = false;
 
     if let Some(jar) = entry.cookie_jar.as_ref() {
-        let session = crate::session::UiSession::new_with_socket(&base_url, Some(jar), target.unix_socket.as_deref())?;
+        let session = crate::session::UiSession::new_with_socket(
+            &base_url,
+            Some(jar),
+            target.unix_socket.as_deref(),
+        )?;
         session_ok = session.test_session().await.unwrap_or(false);
     }
 
@@ -83,7 +87,12 @@ async fn run_status(args: AuthStatusCommand) -> eyre::Result<()> {
             ));
         }
 
-        let session = crate::session::UiSession::from_store_with_socket(&base_url, true, target.unix_socket.as_deref()).await?;
+        let session = crate::session::UiSession::from_store_with_socket(
+            &base_url,
+            true,
+            target.unix_socket.as_deref(),
+        )
+        .await?;
         session_ok = session.test_session().await?;
         relogged = true;
     }
@@ -316,7 +325,11 @@ pub async fn run_nuget_api_key(args: AuthNugetApiKeyCommand) -> eyre::Result<()>
         "write:package"
     };
 
-    let client = crate::api::ApiClient::new_with_socket(&base_url, &fj_api_token, target.unix_socket.as_deref())?;
+    let client = crate::api::ApiClient::new_with_socket(
+        &base_url,
+        &fj_api_token,
+        target.unix_socket.as_deref(),
+    )?;
     let url = client.api_v1_url(&format!("/users/{}/tokens", urlencoding::encode(&username)));
     let body = serde_json::json!({
         "name": token_name,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -58,7 +58,7 @@ async fn run_status(args: AuthStatusCommand) -> eyre::Result<()> {
     let mut relogged = false;
 
     if let Some(jar) = entry.cookie_jar.as_ref() {
-        let session = crate::session::UiSession::new(&base_url, Some(jar))?;
+        let session = crate::session::UiSession::new_with_socket(&base_url, Some(jar), target.unix_socket.as_deref())?;
         session_ok = session.test_session().await.unwrap_or(false);
     }
 
@@ -83,7 +83,7 @@ async fn run_status(args: AuthStatusCommand) -> eyre::Result<()> {
             ));
         }
 
-        let session = crate::session::UiSession::from_store(&base_url, true).await?;
+        let session = crate::session::UiSession::from_store_with_socket(&base_url, true, target.unix_socket.as_deref()).await?;
         session_ok = session.test_session().await?;
         relogged = true;
     }
@@ -316,7 +316,7 @@ pub async fn run_nuget_api_key(args: AuthNugetApiKeyCommand) -> eyre::Result<()>
         "write:package"
     };
 
-    let client = crate::api::ApiClient::new(&base_url, &fj_api_token)?;
+    let client = crate::api::ApiClient::new_with_socket(&base_url, &fj_api_token, target.unix_socket.as_deref())?;
     let url = client.api_v1_url(&format!("/users/{}/tokens", urlencoding::encode(&username)));
     let body = serde_json::json!({
         "name": token_name,

--- a/src/login.rs
+++ b/src/login.rs
@@ -11,7 +11,8 @@ pub async fn run(args: LoginCommand) -> eyre::Result<()> {
     let (username, password) = resolve_creds(args).await?;
 
     // Validate login by actually logging in via UI.
-    let session = crate::session::UiSession::new_with_socket(&base_url, None, target.unix_socket.as_deref())?;
+    let session =
+        crate::session::UiSession::new_with_socket(&base_url, None, target.unix_socket.as_deref())?;
     session.login_with_creds(&username, &password).await?;
 
     // Persist plaintext creds (required by design).

--- a/src/login.rs
+++ b/src/login.rs
@@ -11,7 +11,7 @@ pub async fn run(args: LoginCommand) -> eyre::Result<()> {
     let (username, password) = resolve_creds(args).await?;
 
     // Validate login by actually logging in via UI.
-    let session = crate::session::UiSession::new(&base_url, None)?;
+    let session = crate::session::UiSession::new_with_socket(&base_url, None, target.unix_socket.as_deref())?;
     session.login_with_creds(&username, &password).await?;
 
     // Persist plaintext creds (required by design).

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,6 +48,18 @@ impl UiSession {
         unix_socket: Option<&Path>,
     ) -> eyre::Result<Self> {
         let normalized = crate::target::normalize_base_url(base_url)?;
+
+        // Derive socket from base_url if it's http+unix://
+        // This ensures base_url and unix_socket stay in sync
+        let derived_socket: Option<std::path::PathBuf>;
+        let effective_socket =
+            if let Some((socket, _)) = crate::target::parse_unix_socket_url(&normalized) {
+                derived_socket = Some(socket);
+                derived_socket.as_deref()
+            } else {
+                unix_socket
+            };
+
         let info = store::get_store_entry(&normalized).await?;
         let cookie_jar = if force_relogin {
             None
@@ -55,7 +67,7 @@ impl UiSession {
             info.entry.and_then(|e| e.cookie_jar)
         };
 
-        let session = Self::new_with_socket(&normalized, cookie_jar.as_ref(), unix_socket)?;
+        let session = Self::new_with_socket(&normalized, cookie_jar.as_ref(), effective_socket)?;
         if !force_relogin {
             if session.test_session().await.unwrap_or(false) {
                 let _ = session.persist_cookie_jar().await;
@@ -87,6 +99,18 @@ impl UiSession {
         unix_socket: Option<&Path>,
     ) -> eyre::Result<Self> {
         let base_url = crate::target::normalize_base_url(base_url)?;
+
+        // Derive socket from base_url if it's http+unix://
+        // This ensures base_url and unix_socket stay in sync
+        let derived_socket: Option<std::path::PathBuf>;
+        let effective_socket =
+            if let Some((socket, _)) = crate::target::parse_unix_socket_url(&base_url) {
+                derived_socket = Some(socket);
+                derived_socket.as_deref()
+            } else {
+                unix_socket
+            };
+
         let cookie_store = CookieStoreMutex::new(CookieStore::default());
 
         if let Some(jar) = cookie_jar {
@@ -101,7 +125,7 @@ impl UiSession {
             .cookie_provider(Arc::clone(&cookie_store));
 
         #[cfg(unix)]
-        if let Some(socket_path) = unix_socket {
+        if let Some(socket_path) = effective_socket {
             builder = builder.unix_socket(socket_path);
         }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc, time::Duration};
 
 use cookie_store::{Cookie, CookieExpiration, CookieStore};
 use eyre::{eyre, Context};
@@ -24,6 +24,10 @@ impl UiSession {
     }
 
     pub async fn from_store(base_url: &str, force_relogin: bool) -> eyre::Result<Self> {
+        Self::from_store_with_socket(base_url, force_relogin, None).await
+    }
+
+    pub async fn from_store_with_socket(base_url: &str, force_relogin: bool, unix_socket: Option<&Path>) -> eyre::Result<Self> {
         let normalized = crate::target::normalize_base_url(base_url)?;
         let info = store::get_store_entry(&normalized).await?;
         let cookie_jar = if force_relogin {
@@ -32,7 +36,7 @@ impl UiSession {
             info.entry.and_then(|e| e.cookie_jar)
         };
 
-        let session = Self::new(&normalized, cookie_jar.as_ref())?;
+        let session = Self::new_with_socket(&normalized, cookie_jar.as_ref(), unix_socket)?;
         if !force_relogin {
             if session.test_session().await.unwrap_or(false) {
                 let _ = session.persist_cookie_jar().await;
@@ -55,6 +59,10 @@ impl UiSession {
     }
 
     pub fn new(base_url: &str, cookie_jar: Option<&store::CookieJar>) -> eyre::Result<Self> {
+        Self::new_with_socket(base_url, cookie_jar, None)
+    }
+
+    pub fn new_with_socket(base_url: &str, cookie_jar: Option<&store::CookieJar>, unix_socket: Option<&Path>) -> eyre::Result<Self> {
         let base_url = crate::target::normalize_base_url(base_url)?;
         let cookie_store = CookieStoreMutex::new(CookieStore::default());
 
@@ -63,11 +71,18 @@ impl UiSession {
         }
 
         let cookie_store = Arc::new(cookie_store);
-        let client = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .redirect(Policy::limited(10))
             .timeout(Duration::from_secs(60))
-            .cookie_provider(Arc::clone(&cookie_store))
+            .cookie_provider(Arc::clone(&cookie_store));
+
+        #[cfg(unix)]
+        if let Some(socket_path) = unix_socket {
+            builder = builder.unix_socket(socket_path);
+        }
+
+        let client = builder
             .build()
             .wrap_err("failed to build http client")?;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,6 +20,21 @@ pub struct UiSession {
 
 impl UiSession {
     pub fn base_url(&self) -> &str {
+        self.request_base_url()
+    }
+
+    // Internal helper: get the base URL for HTTP requests
+    // (converts http+unix:// to http://localhost)
+    fn request_base_url(&self) -> &str {
+        if self.base_url.starts_with("http+unix://") {
+            "http://localhost"
+        } else {
+            &self.base_url
+        }
+    }
+
+    // Internal helper: get the storage URL (preserves http+unix://)
+    fn storage_base_url(&self) -> &str {
         &self.base_url
     }
 
@@ -100,7 +115,7 @@ impl UiSession {
     }
 
     pub async fn test_session(&self) -> eyre::Result<bool> {
-        let settings_url = format!("{}/user/settings", self.base_url);
+        let settings_url = format!("{}/user/settings", self.request_base_url());
         let resp = self
             .client
             .get(&settings_url)
@@ -118,16 +133,16 @@ impl UiSession {
     }
 
     pub async fn relogin_from_store(&self) -> eyre::Result<()> {
-        store::clear_cookie_jar(&self.base_url).await?;
+        store::clear_cookie_jar(self.storage_base_url()).await?;
         {
             let mut guard = self.cookie_store.lock().unwrap();
             guard.clear();
         }
 
-        let creds = store::get_ui_creds(&self.base_url).await?.ok_or_else(|| {
+        let creds = store::get_ui_creds(self.storage_base_url()).await?.ok_or_else(|| {
             eyre!(
                 "No stored UI creds for '{}'. Run `fj-ex auth login` (or legacy `fj-ex login`) first.",
-                self.base_url
+                self.storage_base_url()
             )
         })?;
         self.login_with_creds(&creds.username, &creds.password)
@@ -142,7 +157,7 @@ impl UiSession {
             guard.clear();
         }
 
-        let login_url = format!("{}/user/login", self.base_url);
+        let login_url = format!("{}/user/login", self.request_base_url());
         let login_page = self
             .client
             .get(&login_url)
@@ -258,7 +273,7 @@ impl UiSession {
 
     pub async fn persist_cookie_jar(&self) -> eyre::Result<()> {
         let jar = cookie_jar_from_store(&self.cookie_store)?;
-        store::save_cookie_jar(&self.base_url, jar).await?;
+        store::save_cookie_jar(self.storage_base_url(), jar).await?;
         Ok(())
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -27,7 +27,11 @@ impl UiSession {
         Self::from_store_with_socket(base_url, force_relogin, None).await
     }
 
-    pub async fn from_store_with_socket(base_url: &str, force_relogin: bool, unix_socket: Option<&Path>) -> eyre::Result<Self> {
+    pub async fn from_store_with_socket(
+        base_url: &str,
+        force_relogin: bool,
+        unix_socket: Option<&Path>,
+    ) -> eyre::Result<Self> {
         let normalized = crate::target::normalize_base_url(base_url)?;
         let info = store::get_store_entry(&normalized).await?;
         let cookie_jar = if force_relogin {
@@ -62,7 +66,11 @@ impl UiSession {
         Self::new_with_socket(base_url, cookie_jar, None)
     }
 
-    pub fn new_with_socket(base_url: &str, cookie_jar: Option<&store::CookieJar>, unix_socket: Option<&Path>) -> eyre::Result<Self> {
+    pub fn new_with_socket(
+        base_url: &str,
+        cookie_jar: Option<&store::CookieJar>,
+        unix_socket: Option<&Path>,
+    ) -> eyre::Result<Self> {
         let base_url = crate::target::normalize_base_url(base_url)?;
         let cookie_store = CookieStoreMutex::new(CookieStore::default());
 
@@ -82,9 +90,7 @@ impl UiSession {
             builder = builder.unix_socket(socket_path);
         }
 
-        let client = builder
-            .build()
-            .wrap_err("failed to build http client")?;
+        let client = builder.build().wrap_err("failed to build http client")?;
 
         Ok(Self {
             base_url,

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -18,7 +18,12 @@ pub async fn run(args: SmokeTestCommand) -> eyre::Result<()> {
 
     println!();
     println!("[1] Session from store (cookie jar preferred)");
-    let session = crate::session::UiSession::from_store_with_socket(&target.base_url, false, target.unix_socket.as_deref()).await?;
+    let session = crate::session::UiSession::from_store_with_socket(
+        &target.base_url,
+        false,
+        target.unix_socket.as_deref(),
+    )
+    .await?;
 
     println!("[2] Workflows");
     let workflows = crate::ui_actions::list_workflows(&session, &repo, 1, 20).await?;

--- a/src/smoke_test.rs
+++ b/src/smoke_test.rs
@@ -18,7 +18,7 @@ pub async fn run(args: SmokeTestCommand) -> eyre::Result<()> {
 
     println!();
     println!("[1] Session from store (cookie jar preferred)");
-    let session = crate::session::UiSession::from_store(&target.base_url, false).await?;
+    let session = crate::session::UiSession::from_store_with_socket(&target.base_url, false, target.unix_socket.as_deref()).await?;
 
     println!("[2] Workflows");
     let workflows = crate::ui_actions::list_workflows(&session, &repo, 1, 20).await?;

--- a/src/target.rs
+++ b/src/target.rs
@@ -107,9 +107,19 @@ pub fn normalize_base_url(host_or_url: &str) -> eyre::Result<String> {
     }
 
     if trimmed.starts_with("http+unix://") {
-        let (_, base_url) = parse_unix_socket_url(trimmed)
-            .expect("parse_unix_socket_url returns Some when starts_with http+unix://");
-        return Ok(base_url);
+        #[cfg(not(unix))]
+        {
+            return Err(eyre!(
+                "Unix socket URLs (http+unix://) are only supported on Unix platforms"
+            ));
+        }
+
+        #[cfg(unix)]
+        {
+            // Preserve the original http+unix:// URL for storage key uniqueness
+            // (different sockets should have different credential stores)
+            return Ok(trimmed.to_string());
+        }
     }
 
     if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
@@ -313,9 +323,10 @@ pub fn resolve_target(
     if let Some(repo) = repo {
         if let Some(repo_host) = repo.host.as_deref() {
             raw_host = Some(repo_host.to_string());
-            if let Some((socket, base)) = parse_unix_socket_url(repo_host) {
+            if let Some((socket, _base)) = parse_unix_socket_url(repo_host) {
                 resolved_unix_socket = Some(socket);
-                resolved_base_url = Some(base);
+                // Preserve the original http+unix:// URL for storage key uniqueness
+                resolved_base_url = Some(repo_host.to_string());
             } else {
                 resolved_base_url = Some(normalize_base_url(repo_host)?);
             }
@@ -325,9 +336,10 @@ pub fn resolve_target(
     if resolved_base_url.is_none() {
         if let Some(host) = host {
             raw_host = Some(host.to_string());
-            if let Some((socket, base)) = parse_unix_socket_url(host) {
+            if let Some((socket, _base)) = parse_unix_socket_url(host) {
                 resolved_unix_socket = Some(socket);
-                resolved_base_url = Some(base);
+                // Preserve the original http+unix:// URL for storage key uniqueness
+                resolved_base_url = Some(host.to_string());
             } else {
                 resolved_base_url = Some(normalize_base_url(host)?);
             }
@@ -351,9 +363,10 @@ pub fn resolve_target(
     if resolved_base_url.is_none() {
         if let Some(url) = fallback_host_from_env() {
             let url_str = url.as_str();
-            if let Some((socket, base)) = parse_unix_socket_url(url_str) {
+            if let Some((socket, _base)) = parse_unix_socket_url(url_str) {
                 resolved_unix_socket = Some(socket);
-                resolved_base_url = Some(base);
+                // Preserve the original http+unix:// URL for storage key uniqueness
+                resolved_base_url = Some(url_str.to_string());
             } else {
                 let base = normalize_base_url(url_str)?;
                 resolved_base_url = Some(base);
@@ -482,11 +495,18 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn normalize_base_url_handles_unix_socket() {
         assert_eq!(
             normalize_base_url("http+unix:///run/forgejo/http.sock").unwrap(),
-            "http://localhost"
+            "http+unix:///run/forgejo/http.sock"
         );
+    }
+
+    #[test]
+    #[cfg(not(unix))]
+    fn normalize_base_url_rejects_unix_socket_on_non_unix() {
+        assert!(normalize_base_url("http+unix:///run/forgejo/http.sock").is_err());
     }
 
     #[test]

--- a/src/target.rs
+++ b/src/target.rs
@@ -94,6 +94,12 @@ pub fn parse_unix_socket_url(url: &str) -> Option<(PathBuf, String)> {
 
     // Percent-decode the path
     let decoded = urlencoding::decode(without_scheme).ok()?;
+
+    // Validate the decoded path is non-empty
+    if decoded.trim().is_empty() {
+        return None;
+    }
+
     let socket_path = PathBuf::from(decoded.as_ref());
 
     let base_url = "http://localhost".to_string();
@@ -323,12 +329,12 @@ pub fn resolve_target(
     if let Some(repo) = repo {
         if let Some(repo_host) = repo.host.as_deref() {
             raw_host = Some(repo_host.to_string());
-            if let Some((socket, _base)) = parse_unix_socket_url(repo_host) {
+            // Normalize first to ensure platform validation happens
+            let normalized = normalize_base_url(repo_host)?;
+            resolved_base_url = Some(normalized.clone());
+            // Then extract socket from the normalized URL
+            if let Some((socket, _base)) = parse_unix_socket_url(&normalized) {
                 resolved_unix_socket = Some(socket);
-                // Preserve the original http+unix:// URL for storage key uniqueness
-                resolved_base_url = Some(repo_host.to_string());
-            } else {
-                resolved_base_url = Some(normalize_base_url(repo_host)?);
             }
         }
     }
@@ -336,12 +342,12 @@ pub fn resolve_target(
     if resolved_base_url.is_none() {
         if let Some(host) = host {
             raw_host = Some(host.to_string());
-            if let Some((socket, _base)) = parse_unix_socket_url(host) {
+            // Normalize first to ensure platform validation happens
+            let normalized = normalize_base_url(host)?;
+            resolved_base_url = Some(normalized.clone());
+            // Then extract socket from the normalized URL
+            if let Some((socket, _base)) = parse_unix_socket_url(&normalized) {
                 resolved_unix_socket = Some(socket);
-                // Preserve the original http+unix:// URL for storage key uniqueness
-                resolved_base_url = Some(host.to_string());
-            } else {
-                resolved_base_url = Some(normalize_base_url(host)?);
             }
         }
     }
@@ -363,13 +369,12 @@ pub fn resolve_target(
     if resolved_base_url.is_none() {
         if let Some(url) = fallback_host_from_env() {
             let url_str = url.as_str();
-            if let Some((socket, _base)) = parse_unix_socket_url(url_str) {
+            // Normalize first to ensure platform validation happens
+            let normalized = normalize_base_url(url_str)?;
+            resolved_base_url = Some(normalized.clone());
+            // Then extract socket from the normalized URL
+            if let Some((socket, _base)) = parse_unix_socket_url(&normalized) {
                 resolved_unix_socket = Some(socket);
-                // Preserve the original http+unix:// URL for storage key uniqueness
-                resolved_base_url = Some(url_str.to_string());
-            } else {
-                let base = normalize_base_url(url_str)?;
-                resolved_base_url = Some(base);
             }
         }
     }
@@ -515,5 +520,11 @@ mod tests {
             normalize_host_key("http+unix:///run/forgejo/http.sock").unwrap(),
             "http+unix:///run/forgejo/http.sock"
         );
+    }
+
+    #[test]
+    fn parse_unix_socket_url_rejects_empty_path() {
+        assert_eq!(parse_unix_socket_url("http+unix://"), None);
+        assert_eq!(parse_unix_socket_url("http+unix://   "), None);
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -122,6 +122,15 @@ pub fn normalize_base_url(host_or_url: &str) -> eyre::Result<String> {
 
         #[cfg(unix)]
         {
+            // Validate that the URL contains a non-empty socket path
+            // This prevents malformed URLs like "http+unix://" from passing through
+            // and later falling back to TCP localhost with confusing errors
+            if parse_unix_socket_url(trimmed).is_none() {
+                return Err(eyre!(
+                    "Invalid Unix socket URL: '{}'. Expected format: http+unix:///path/to/socket.sock",
+                    trimmed
+                ));
+            }
             // Preserve the original http+unix:// URL for storage key uniqueness
             // (different sockets should have different credential stores)
             return Ok(trimmed.to_string());
@@ -526,5 +535,14 @@ mod tests {
     fn parse_unix_socket_url_rejects_empty_path() {
         assert_eq!(parse_unix_socket_url("http+unix://"), None);
         assert_eq!(parse_unix_socket_url("http+unix://   "), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn normalize_base_url_rejects_malformed_unix_socket_url() {
+        // Empty path should fail
+        assert!(normalize_base_url("http+unix://").is_err());
+        // Whitespace-only path should fail
+        assert!(normalize_base_url("http+unix://   ").is_err());
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use eyre::{eyre, Context};
 use url::Url;
@@ -91,7 +91,10 @@ pub fn parse_unix_socket_url(url: &str) -> Option<(PathBuf, String)> {
     }
 
     let without_scheme = url.trim_start_matches("http+unix://");
-    let socket_path = PathBuf::from(without_scheme);
+
+    // Percent-decode the path
+    let decoded = urlencoding::decode(without_scheme).ok()?;
+    let socket_path = PathBuf::from(decoded.as_ref());
 
     let base_url = "http://localhost".to_string();
     Some((socket_path, base_url))
@@ -104,10 +107,9 @@ pub fn normalize_base_url(host_or_url: &str) -> eyre::Result<String> {
     }
 
     if trimmed.starts_with("http+unix://") {
-        if let Some((_, base_url)) = parse_unix_socket_url(trimmed) {
-            return Ok(base_url);
-        }
-        return Err(eyre!("invalid unix socket url"));
+        let (_, base_url) = parse_unix_socket_url(trimmed)
+            .expect("parse_unix_socket_url returns Some when starts_with http+unix://");
+        return Ok(base_url);
     }
 
     if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
@@ -452,6 +454,30 @@ mod tests {
         assert!(result.is_some());
         let (socket, base) = result.unwrap();
         assert_eq!(socket, PathBuf::from("/run/forgejo/http.sock"));
+        assert_eq!(base, "http://localhost");
+    }
+
+    #[test]
+    fn parse_unix_socket_url_with_dynamic_path() {
+        // Test with a dynamic path to verify the parser works correctly
+        let test_path = PathBuf::from("/tmp/test/socket.sock");
+        let socket_url = format!("http+unix://{}", test_path.display());
+
+        let result = parse_unix_socket_url(&socket_url);
+        assert!(result.is_some());
+
+        let (parsed_socket, parsed_base) = result.unwrap();
+        assert_eq!(parsed_socket, test_path);
+        assert_eq!(parsed_base, "http://localhost");
+    }
+
+    #[test]
+    fn parse_unix_socket_url_with_percent_encoding() {
+        // Test percent-encoded paths
+        let result = parse_unix_socket_url("http+unix:///run/my%20socket/http.sock");
+        assert!(result.is_some());
+        let (socket, base) = result.unwrap();
+        assert_eq!(socket, PathBuf::from("/run/my socket/http.sock"));
         assert_eq!(base, "http://localhost");
     }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::path::PathBuf;
 
 use eyre::{eyre, Context};
 use url::Url;
@@ -81,12 +82,32 @@ pub struct ResolvedTarget {
     pub repo: Option<String>,
     pub owner: Option<String>,
     pub name: Option<String>,
+    pub unix_socket: Option<PathBuf>,
+}
+
+pub fn parse_unix_socket_url(url: &str) -> Option<(PathBuf, String)> {
+    if !url.starts_with("http+unix://") {
+        return None;
+    }
+
+    let without_scheme = url.trim_start_matches("http+unix://");
+    let socket_path = PathBuf::from(without_scheme);
+
+    let base_url = "http://localhost".to_string();
+    Some((socket_path, base_url))
 }
 
 pub fn normalize_base_url(host_or_url: &str) -> eyre::Result<String> {
     let trimmed = host_or_url.trim();
     if trimmed.is_empty() {
         return Err(eyre!("host is required"));
+    }
+
+    if trimmed.starts_with("http+unix://") {
+        if let Some((_, base_url)) = parse_unix_socket_url(trimmed) {
+            return Ok(base_url);
+        }
+        return Err(eyre!("invalid unix socket url"));
     }
 
     if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
@@ -114,6 +135,10 @@ pub fn normalize_host_key(host_or_url: &str) -> eyre::Result<String> {
     let trimmed = host_or_url.trim();
     if trimmed.is_empty() {
         return Err(eyre!("host is required"));
+    }
+
+    if trimmed.starts_with("http+unix://") {
+        return Ok(trimmed.to_string());
     }
 
     if trimmed.starts_with("http://")
@@ -280,21 +305,35 @@ pub fn resolve_target(
     });
 
     let mut resolved_base_url: Option<String> = None;
+    let mut resolved_unix_socket: Option<PathBuf> = None;
+    let mut raw_host: Option<String> = None;
 
     if let Some(repo) = repo {
         if let Some(repo_host) = repo.host.as_deref() {
-            resolved_base_url = Some(normalize_base_url(repo_host)?);
+            raw_host = Some(repo_host.to_string());
+            if let Some((socket, base)) = parse_unix_socket_url(repo_host) {
+                resolved_unix_socket = Some(socket);
+                resolved_base_url = Some(base);
+            } else {
+                resolved_base_url = Some(normalize_base_url(repo_host)?);
+            }
         }
     }
 
     if resolved_base_url.is_none() {
         if let Some(host) = host {
-            resolved_base_url = Some(normalize_base_url(host)?);
+            raw_host = Some(host.to_string());
+            if let Some((socket, base)) = parse_unix_socket_url(host) {
+                resolved_unix_socket = Some(socket);
+                resolved_base_url = Some(base);
+            } else {
+                resolved_base_url = Some(normalize_base_url(host)?);
+            }
         }
     }
 
     if resolved_base_url.is_none() || resolved_repo.is_none() {
-        if let Some((base, repo_name)) = infer_from_git(remote, host)? {
+        if let Some((base, repo_name)) = infer_from_git(remote, raw_host.as_deref())? {
             resolved_base_url.get_or_insert(base);
             if resolved_repo.is_none() {
                 resolved_repo = Some(
@@ -309,8 +348,14 @@ pub fn resolve_target(
 
     if resolved_base_url.is_none() {
         if let Some(url) = fallback_host_from_env() {
-            let base = normalize_base_url(url.as_str())?;
-            resolved_base_url = Some(base);
+            let url_str = url.as_str();
+            if let Some((socket, base)) = parse_unix_socket_url(url_str) {
+                resolved_unix_socket = Some(socket);
+                resolved_base_url = Some(base);
+            } else {
+                let base = normalize_base_url(url_str)?;
+                resolved_base_url = Some(base);
+            }
         }
     }
 
@@ -325,6 +370,7 @@ pub fn resolve_target(
         owner: resolved_repo.as_ref().map(|r| r.owner.clone()),
         name: resolved_repo.as_ref().map(|r| r.name.clone()),
         base_url,
+        unix_socket: resolved_unix_socket,
     })
 }
 
@@ -398,5 +444,30 @@ mod tests {
             .unwrap();
         assert_eq!(host, "forge.example.com");
         assert_eq!(repo.as_owner_slash_name(), "alice/widgets");
+    }
+
+    #[test]
+    fn parse_unix_socket_url_works() {
+        let result = parse_unix_socket_url("http+unix:///run/forgejo/http.sock");
+        assert!(result.is_some());
+        let (socket, base) = result.unwrap();
+        assert_eq!(socket, PathBuf::from("/run/forgejo/http.sock"));
+        assert_eq!(base, "http://localhost");
+    }
+
+    #[test]
+    fn normalize_base_url_handles_unix_socket() {
+        assert_eq!(
+            normalize_base_url("http+unix:///run/forgejo/http.sock").unwrap(),
+            "http://localhost"
+        );
+    }
+
+    #[test]
+    fn normalize_host_key_preserves_unix_socket() {
+        assert_eq!(
+            normalize_host_key("http+unix:///run/forgejo/http.sock").unwrap(),
+            "http+unix:///run/forgejo/http.sock"
+        );
     }
 }

--- a/tests/unix_socket_test.rs
+++ b/tests/unix_socket_test.rs
@@ -10,14 +10,10 @@ use tempfile::TempDir;
 
 const FORGEJO_ROOTLESS_IMAGE: &str = "codeberg.org/forgejo/forgejo:14-rootless";
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[tokio::test]
 #[ignore]
 async fn test_unix_socket_connection() -> Result<()> {
-    if !cfg!(target_os = "linux") {
-        eprintln!("skipping unix socket test: requires Linux");
-        return Ok(());
-    }
     if std::env::var("FJ_EX_UNIX_SOCKET_TEST").ok().as_deref() != Some("1") {
         eprintln!("skipping unix socket test: set FJ_EX_UNIX_SOCKET_TEST=1 to enable");
         return Ok(());
@@ -39,11 +35,8 @@ async fn test_unix_socket_connection() -> Result<()> {
     let socket_path = sockets_dir.join("http.sock");
 
     println!("Starting Forgejo container with Unix socket...");
-    let _container = ForgejoUnixSocketContainer::start(
-        &container_name,
-        &sockets_dir,
-        &data_dir,
-    ).await?;
+    let _container =
+        ForgejoUnixSocketContainer::start(&container_name, &sockets_dir, &data_dir).await?;
 
     // Wait for socket to be created
     wait_for_socket(&socket_path, Duration::from_secs(30))?;
@@ -70,12 +63,11 @@ async fn test_unix_socket_connection() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn test_unix_socket_url_parsing(socket_path: &Path) -> Result<()> {
-    // Test the parse_unix_socket_url function
+    // Test that the URL format is correct
     let socket_url = format!("http+unix://{}", socket_path.display());
 
-    // This tests that our URL parsing works
     assert!(socket_url.starts_with("http+unix://"));
     assert!(socket_url.contains("http.sock"));
 
@@ -83,7 +75,7 @@ fn test_unix_socket_url_parsing(socket_path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn test_curl_unix_socket(socket_path: &Path) -> Result<()> {
     let output = Command::new("curl")
         .arg("--unix-socket")
@@ -109,7 +101,7 @@ fn test_curl_unix_socket(socket_path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn test_fj_ex_login(socket_path: &Path, temp: &TempDir) -> Result<()> {
     let fj_ex = fj_ex_bin()?;
     let socket_url = format!("http+unix://{}", socket_path.display());
@@ -149,7 +141,7 @@ fn test_fj_ex_login(socket_path: &Path, temp: &TempDir) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn test_fj_ex_status(socket_path: &Path, temp: &TempDir) -> Result<()> {
     let fj_ex = fj_ex_bin()?;
     let socket_url = format!("http+unix://{}", socket_path.display());
@@ -183,7 +175,36 @@ fn test_fj_ex_status(socket_path: &Path, temp: &TempDir) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
+fn wait_for_forgejo_ready(container_name: &str, timeout: Duration) -> Result<()> {
+    let start = std::time::Instant::now();
+    let poll_interval = Duration::from_millis(500);
+
+    while start.elapsed() < timeout {
+        let output = Command::new("docker")
+            .args([
+                "exec",
+                container_name,
+                "curl",
+                "--silent",
+                "--fail",
+                "http://localhost:3000/api/v1/version",
+            ])
+            .output();
+
+        if let Ok(output) = output {
+            if output.status.success() {
+                return Ok(());
+            }
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+
+    Err(eyre!("Forgejo did not become ready within timeout"))
+}
+
+#[cfg(target_os = "linux")]
 fn wait_for_socket(socket_path: &Path, timeout: Duration) -> Result<()> {
     let start = std::time::Instant::now();
 
@@ -191,7 +212,7 @@ fn wait_for_socket(socket_path: &Path, timeout: Duration) -> Result<()> {
         if socket_path.exists() {
             // Additional check: try to stat the socket
             if let Ok(metadata) = fs::metadata(socket_path) {
-                #[cfg(unix)]
+                #[cfg(target_os = "linux")]
                 {
                     use std::os::unix::fs::FileTypeExt;
                     if metadata.file_type().is_socket() {
@@ -206,11 +227,17 @@ fn wait_for_socket(socket_path: &Path, timeout: Duration) -> Result<()> {
     Err(eyre!("Socket not created within timeout"))
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn create_admin_user_in_container() -> Result<()> {
     // Find the running container
     let containers = Command::new("docker")
-        .args(["ps", "--filter", "name=fj-ex-unix-test", "--format", "{{.Names}}"])
+        .args([
+            "ps",
+            "--filter",
+            "name=fj-ex-unix-test",
+            "--format",
+            "{{.Names}}",
+        ])
         .output()
         .wrap_err("failed to list containers")?;
 
@@ -220,8 +247,8 @@ fn create_admin_user_in_container() -> Result<()> {
         .ok_or_else(|| eyre!("no test container found"))?
         .to_string();
 
-    // Wait for Forgejo to be ready
-    std::thread::sleep(Duration::from_secs(5));
+    // Wait for Forgejo to be ready by polling the health endpoint
+    wait_for_forgejo_ready(&container_name, Duration::from_secs(30))?;
 
     let output = Command::new("docker")
         .args([
@@ -253,24 +280,22 @@ fn create_admin_user_in_container() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 struct ForgejoUnixSocketContainer {
     name: String,
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 impl ForgejoUnixSocketContainer {
-    async fn start(
-        name: &str,
-        sockets_dir: &Path,
-        data_dir: &Path,
-    ) -> Result<Self> {
+    async fn start(name: &str, sockets_dir: &Path, data_dir: &Path) -> Result<Self> {
         // Create initial app.ini
         let conf_dir = data_dir.join("custom").join("conf");
         fs::create_dir_all(&conf_dir)?;
 
         let app_ini = conf_dir.join("app.ini");
-        fs::write(&app_ini, r#"
+        fs::write(
+            &app_ini,
+            r#"
 [server]
 PROTOCOL = http+unix
 HTTP_ADDR = /run/forgejo/http.sock
@@ -289,7 +314,8 @@ INSTALL_LOCK = true
 [service]
 DISABLE_REGISTRATION = false
 REQUIRE_SIGNIN_VIEW = false
-"#)?;
+"#,
+        )?;
 
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
@@ -298,10 +324,14 @@ REQUIRE_SIGNIN_VIEW = false
             .args([
                 "run",
                 "-d",
-                "--name", name,
-                "--user", &format!("{}:{}", uid, gid),
-                "-v", &format!("{}:/var/lib/gitea", data_dir.display()),
-                "-v", &format!("{}:/run/forgejo", sockets_dir.display()),
+                "--name",
+                name,
+                "--user",
+                &format!("{}:{}", uid, gid),
+                "-v",
+                &format!("{}:/var/lib/gitea", data_dir.display()),
+                "-v",
+                &format!("{}:/run/forgejo", sockets_dir.display()),
                 FORGEJO_ROOTLESS_IMAGE,
             ])
             .output()
@@ -320,7 +350,7 @@ REQUIRE_SIGNIN_VIEW = false
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 impl Drop for ForgejoUnixSocketContainer {
     fn drop(&mut self) {
         let _ = Command::new("docker")
@@ -341,7 +371,11 @@ fn docker_available() -> bool {
 
 fn fj_ex_bin() -> Result<PathBuf> {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let target_dir = Path::new(manifest_dir).join("target");
+
+    // Check CARGO_TARGET_DIR first, then fall back to target/ under manifest dir
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| Path::new(manifest_dir).join("target"));
 
     // Try debug first, then release
     let debug_bin = target_dir.join("debug").join("fj-ex");

--- a/tests/unix_socket_test.rs
+++ b/tests/unix_socket_test.rs
@@ -186,9 +186,11 @@ fn wait_for_forgejo_ready(container_name: &str, timeout: Duration) -> Result<()>
                 "exec",
                 container_name,
                 "curl",
+                "--unix-socket",
+                "/run/forgejo/http.sock",
                 "--silent",
                 "--fail",
-                "http://localhost:3000/api/v1/version",
+                "http://localhost/api/v1/version",
             ])
             .output();
 

--- a/tests/unix_socket_test.rs
+++ b/tests/unix_socket_test.rs
@@ -1,0 +1,357 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+use eyre::{eyre, Context, Result};
+use tempfile::TempDir;
+
+const FORGEJO_ROOTLESS_IMAGE: &str = "codeberg.org/forgejo/forgejo:14-rootless";
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore]
+async fn test_unix_socket_connection() -> Result<()> {
+    if !cfg!(target_os = "linux") {
+        eprintln!("skipping unix socket test: requires Linux");
+        return Ok(());
+    }
+    if std::env::var("FJ_EX_UNIX_SOCKET_TEST").ok().as_deref() != Some("1") {
+        eprintln!("skipping unix socket test: set FJ_EX_UNIX_SOCKET_TEST=1 to enable");
+        return Ok(());
+    }
+    if !docker_available() {
+        eprintln!("skipping unix socket test: docker is not available");
+        return Ok(());
+    }
+
+    let temp = tempfile::tempdir().wrap_err("failed to create temp dir")?;
+    let sockets_dir = temp.path().join("sockets");
+    let data_dir = temp.path().join("data");
+
+    fs::create_dir_all(&sockets_dir).wrap_err("failed to create sockets dir")?;
+    fs::create_dir_all(&data_dir).wrap_err("failed to create data dir")?;
+
+    let test_id = format!("{}", std::process::id());
+    let container_name = format!("fj-ex-unix-test-{test_id}");
+    let socket_path = sockets_dir.join("http.sock");
+
+    println!("Starting Forgejo container with Unix socket...");
+    let _container = ForgejoUnixSocketContainer::start(
+        &container_name,
+        &sockets_dir,
+        &data_dir,
+    ).await?;
+
+    // Wait for socket to be created
+    wait_for_socket(&socket_path, Duration::from_secs(30))?;
+
+    println!("Socket created at: {}", socket_path.display());
+
+    // Test 1: Parse unix socket URL
+    println!("\nTest 1: URL parsing");
+    test_unix_socket_url_parsing(&socket_path)?;
+
+    // Test 2: Test connection with curl
+    println!("\nTest 2: Connection with curl");
+    test_curl_unix_socket(&socket_path)?;
+
+    // Test 3: Test fj-ex auth login
+    println!("\nTest 3: fj-ex auth login via Unix socket");
+    test_fj_ex_login(&socket_path, &temp)?;
+
+    // Test 4: Test fj-ex auth status
+    println!("\nTest 4: fj-ex auth status via Unix socket");
+    test_fj_ex_status(&socket_path, &temp)?;
+
+    println!("\n✅ All Unix socket tests passed!");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn test_unix_socket_url_parsing(socket_path: &Path) -> Result<()> {
+    // Test the parse_unix_socket_url function
+    let socket_url = format!("http+unix://{}", socket_path.display());
+
+    // This tests that our URL parsing works
+    assert!(socket_url.starts_with("http+unix://"));
+    assert!(socket_url.contains("http.sock"));
+
+    println!("  ✓ URL format: {}", socket_url);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn test_curl_unix_socket(socket_path: &Path) -> Result<()> {
+    let output = Command::new("curl")
+        .arg("--unix-socket")
+        .arg(socket_path)
+        .arg("http://localhost/api/v1/version")
+        .arg("--silent")
+        .arg("--fail")
+        .output()
+        .wrap_err("failed to run curl")?;
+
+    if !output.status.success() {
+        return Err(eyre!(
+            "curl failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let response = String::from_utf8_lossy(&output.stdout);
+    assert!(response.contains("version"), "Expected version in response");
+
+    println!("  ✓ curl connection successful");
+    println!("  ✓ Response: {}", response);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn test_fj_ex_login(socket_path: &Path, temp: &TempDir) -> Result<()> {
+    let fj_ex = fj_ex_bin()?;
+    let socket_url = format!("http+unix://{}", socket_path.display());
+    let appdata = temp.path().join("appdata");
+    fs::create_dir_all(&appdata)?;
+
+    // Create admin user in container first
+    create_admin_user_in_container()?;
+
+    let output = Command::new(&fj_ex)
+        .env("HOME", temp.path())
+        .env("XDG_DATA_HOME", appdata.join("share"))
+        .arg("auth")
+        .arg("login")
+        .arg("-H")
+        .arg(&socket_url)
+        .arg("--userpass")
+        .arg("testadmin:testpass123")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .wrap_err("failed to run fj-ex auth login")?;
+
+    if !output.status.success() {
+        eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return Err(eyre!("fj-ex auth login failed"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("testadmin@localhost") || stdout.contains("Saved UI creds"),
+        "Expected login success message"
+    );
+
+    println!("  ✓ fj-ex auth login successful");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn test_fj_ex_status(socket_path: &Path, temp: &TempDir) -> Result<()> {
+    let fj_ex = fj_ex_bin()?;
+    let socket_url = format!("http+unix://{}", socket_path.display());
+    let appdata = temp.path().join("appdata");
+
+    let output = Command::new(&fj_ex)
+        .env("HOME", temp.path())
+        .env("XDG_DATA_HOME", appdata.join("share"))
+        .arg("auth")
+        .arg("status")
+        .arg("-H")
+        .arg(&socket_url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .wrap_err("failed to run fj-ex auth status")?;
+
+    if !output.status.success() {
+        eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return Err(eyre!("fj-ex auth status failed"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("testadmin@localhost") || stdout.contains("OK"),
+        "Expected status success"
+    );
+
+    println!("  ✓ fj-ex auth status successful");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn wait_for_socket(socket_path: &Path, timeout: Duration) -> Result<()> {
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < timeout {
+        if socket_path.exists() {
+            // Additional check: try to stat the socket
+            if let Ok(metadata) = fs::metadata(socket_path) {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::FileTypeExt;
+                    if metadata.file_type().is_socket() {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    Err(eyre!("Socket not created within timeout"))
+}
+
+#[cfg(unix)]
+fn create_admin_user_in_container() -> Result<()> {
+    // Find the running container
+    let containers = Command::new("docker")
+        .args(["ps", "--filter", "name=fj-ex-unix-test", "--format", "{{.Names}}"])
+        .output()
+        .wrap_err("failed to list containers")?;
+
+    let container_name = String::from_utf8_lossy(&containers.stdout)
+        .lines()
+        .next()
+        .ok_or_else(|| eyre!("no test container found"))?
+        .to_string();
+
+    // Wait for Forgejo to be ready
+    std::thread::sleep(Duration::from_secs(5));
+
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            &container_name,
+            "forgejo",
+            "admin",
+            "user",
+            "create",
+            "--admin",
+            "--username",
+            "testadmin",
+            "--password",
+            "testpass123",
+            "--email",
+            "test@example.com",
+        ])
+        .output()
+        .wrap_err("failed to create admin user")?;
+
+    // It's ok if user already exists
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("already exist") && !stderr.contains("reserved") {
+            eprintln!("Warning: admin user creation failed: {}", stderr);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+struct ForgejoUnixSocketContainer {
+    name: String,
+}
+
+#[cfg(unix)]
+impl ForgejoUnixSocketContainer {
+    async fn start(
+        name: &str,
+        sockets_dir: &Path,
+        data_dir: &Path,
+    ) -> Result<Self> {
+        // Create initial app.ini
+        let conf_dir = data_dir.join("custom").join("conf");
+        fs::create_dir_all(&conf_dir)?;
+
+        let app_ini = conf_dir.join("app.ini");
+        fs::write(&app_ini, r#"
+[server]
+PROTOCOL = http+unix
+HTTP_ADDR = /run/forgejo/http.sock
+UNIX_SOCKET_PERMISSION = 660
+DOMAIN = localhost
+ROOT_URL = http://localhost/
+START_SSH_SERVER = false
+
+[database]
+DB_TYPE = sqlite3
+PATH = /var/lib/gitea/data/gitea.db
+
+[security]
+INSTALL_LOCK = true
+
+[service]
+DISABLE_REGISTRATION = false
+REQUIRE_SIGNIN_VIEW = false
+"#)?;
+
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "-d",
+                "--name", name,
+                "--user", &format!("{}:{}", uid, gid),
+                "-v", &format!("{}:/var/lib/gitea", data_dir.display()),
+                "-v", &format!("{}:/run/forgejo", sockets_dir.display()),
+                FORGEJO_ROOTLESS_IMAGE,
+            ])
+            .output()
+            .wrap_err("failed to start forgejo container")?;
+
+        if !output.status.success() {
+            return Err(eyre!(
+                "docker run failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(Self {
+            name: name.to_string(),
+        })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ForgejoUnixSocketContainer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .output();
+    }
+}
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn fj_ex_bin() -> Result<PathBuf> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let target_dir = Path::new(manifest_dir).join("target");
+
+    // Try debug first, then release
+    let debug_bin = target_dir.join("debug").join("fj-ex");
+    let release_bin = target_dir.join("release").join("fj-ex");
+
+    if release_bin.exists() {
+        Ok(release_bin)
+    } else if debug_bin.exists() {
+        Ok(debug_bin)
+    } else {
+        Err(eyre!("fj-ex binary not found. Run 'cargo build' first"))
+    }
+}


### PR DESCRIPTION
Enables fj-ex to connect to Forgejo instances via Unix sockets. Implements http+unix:// URL parsing and socket-based HTTP client configuration across ApiClient and UiSession.

- Add parse_unix_socket_url() and socket path tracking in target.rs
- Extend ApiClient and UiSession with unix_socket parameter
- Update all client instantiation sites to pass socket paths
- Add comprehensive integration test (unix_socket_test.rs)
- Update CI workflow to run Unix socket tests
- Add libc dev dependency for Unix platform support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unix socket support for API connections and authentication sessions.
  * Support for the http+unix:// URL scheme for socket-based endpoints.

* **Tests**
  * Added a Linux-only integration test that validates full unix-socket end-to-end flows (opt-in via env).
  * CI e2e job extended to run the unix-socket test step before publish.

* **Chores**
  * Added a Unix-specific development dependency for native socket support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->